### PR TITLE
feat: Introduce `forceBrackets` for optional icon brackets

### DIFF
--- a/packages/plugin/src/helpers/options.ts
+++ b/packages/plugin/src/helpers/options.ts
@@ -23,6 +23,9 @@ export interface DynamicIconifyPluginOptions
 	// Include icon-specific selectors only
 	overrideOnly?: boolean;
 
+	// if set to 'false', these both will work: 'icon-[mdi--home]', 'icon-mdi--home'
+	forceBrackets?: boolean;
+
 	// Sets the default height/width value (ex. scale: 2 = 2em)
 	scale?: number;
 }

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -63,6 +63,13 @@ const exportedPlugin = plugin.withOptions((params: unknown) => {
 				);
 				return;
 
+			case 'forceBrackets':
+			case 'force-brackets':
+			case 'forcebrackets': {
+				dynamicOptions.forceBrackets = getBooleanValue(value, dynamicOptions.forceBrackets ?? true);
+				return;
+			}
+
 			// Options for preparsed plugin
 			case 'prefixes': {
 				// prefixes: foo;
@@ -131,6 +138,26 @@ const exportedPlugin = plugin.withOptions((params: unknown) => {
 		// Dynamic plugin
 		const prefix = dynamicOptions.prefix ?? 'icon';
 		if (prefix) {
+			let values = undefined;
+			if(dynamicOptions.forceBrackets === false){
+				const target = {};
+
+				const handler = {
+					get(target, prop, receiver) {
+						if(!prop.includes('--'))
+							return undefined;
+						if(prop.startsWith('-'))
+							prop = prop.substring(1);
+						if(prop.startsWith('['))
+							prop = prop.substring(1);
+						if(prop.endsWith(']'))
+							prop = prop.substring(0, prop.length - 1);
+						return prop;
+					}
+				};
+				values = new Proxy(target, handler);
+			}
+			console.log({ values });
 			matchComponents({
 				[prefix]: (icon: string) => {
 					try {
@@ -141,6 +168,8 @@ const exportedPlugin = plugin.withOptions((params: unknown) => {
 						return {};
 					}
 				},
+			},{
+				values
 			});
 		}
 

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -157,7 +157,7 @@ const exportedPlugin = plugin.withOptions((params: unknown) => {
 				};
 				values = new Proxy(target, handler);
 			}
-			console.log({ values });
+
 			matchComponents({
 				[prefix]: (icon: string) => {
 					try {


### PR DESCRIPTION
This commit adds a boolean `forceBrackets` option to the configuration.

Problem: Icon classes previously always required square brackets, like `icon-[set--name]`.
Solution: Setting `forceBrackets: false` makes these brackets optional.

Behavior:
- `forceBrackets: true` (Default): Only `icon-[set--name]` is valid.
- `forceBrackets: false`: Both `icon-[set--name]` and `icon-set--name` are valid.

Example (`forceBrackets: false`):
- `icon-[mdi--close]`  ✅
- `icon-mdi--close`   ✅

This enhances user flexibility and accommodates different coding style preferences.

---

![image](https://github.com/user-attachments/assets/23961215-7a82-4a9c-9210-4646abe30060)
